### PR TITLE
Deploy on release published

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,10 +1,10 @@
 ---
-name: Act on release created
+name: Act on release published
 
 "on":
   release:
     types:
-      - created
+      - published
 
 jobs:
   deploy:


### PR DESCRIPTION
Based on recommendations of [this topic](https://stackoverflow.com/questions/59319281/github-action-different-between-release-created-and-published).